### PR TITLE
Add support for receiving the client IP address in the TCPs modules

### DIFF
--- a/intfs/TCPFwUpdateModule/TCPFwUpdateModule.cpp
+++ b/intfs/TCPFwUpdateModule/TCPFwUpdateModule.cpp
@@ -126,6 +126,19 @@ void TCPFwUpdateModule::_task() {
                 nsapi_status);
         } while(nsapi_status != NSAPI_ERROR_OK);
 
+        /* Get connected client information */
+        SocketAddress client_addr;
+        nsapi_status = p_client->getpeername(&client_addr);
+        if(nsapi_status == NSAPI_ERROR_OK) {
+            debug("[TCPCtrlIntfModule::_task] client_addr.get_ip_address: "
+                  "%s\n", client_addr.get_ip_address());
+            debug("[TCPCtrlIntfModule::_task] client_addr.get_port: %u\n",
+                  client_addr.get_port());
+        } else {
+            debug("[TCPCtrlIntfModule::_task] p_client->getpeername rc: %d\n",
+                  nsapi_status);
+        }
+
         /* Not blocking from now on */
         p_client->set_timeout(_timeout);
 

--- a/intfs/ctrl/TCPCtrlIntfModule/TCPCtrlIntfModule.cpp
+++ b/intfs/ctrl/TCPCtrlIntfModule/TCPCtrlIntfModule.cpp
@@ -51,6 +51,19 @@ void TCPCtrlIntfModule::_task() {
             nsapi_status);
     } while(nsapi_status != NSAPI_ERROR_OK);
 
+    /* Get connected client information */
+    SocketAddress client_addr;
+    nsapi_status = client->getpeername(&client_addr);
+    if(nsapi_status == NSAPI_ERROR_OK) {
+      debug("[TCPCtrlIntfModule::_task] client_addr.get_ip_address: %s\n",
+            client_addr.get_ip_address());
+      debug("[TCPCtrlIntfModule::_task] client_addr.get_port: %u\n",
+            client_addr.get_port());
+    } else {
+      debug("[TCPCtrlIntfModule::_task] client->getpeername rc: %d\n",
+            nsapi_status);
+    }
+
     /* Not blocking from now on */
     client->set_timeout(_timeout);
 

--- a/intfs/stream/TCPStreamIntfModule/TCPStreamIntfModule.cpp
+++ b/intfs/stream/TCPStreamIntfModule/TCPStreamIntfModule.cpp
@@ -74,6 +74,19 @@ TCPStreamIntfModule::TCPStreamIntfModule(
 
           if(nsapi_status == NSAPI_ERROR_OK) {
             is_client_accepted = true;
+
+            /* Get connected client information */
+            SocketAddress client_addr;
+            nsapi_status = client->getpeername(&client_addr);
+            if(nsapi_status == NSAPI_ERROR_OK) {
+              debug("[TCPStreamIntfModule::_task] client_addr.get_ip_address: "
+                    "%s\n", client_addr.get_ip_address());
+              debug("[TCPStreamIntfModule::_task] client_addr.get_port: %u\n",
+                    client_addr.get_port());
+            } else {
+              debug("[TCPStreamIntfModule::_task] client->getpeername rc: "
+                    "%d\n", nsapi_status);
+            }
           }
         }
 


### PR DESCRIPTION
Update TCPCtrlIntfModule, TCPFwUpdateModule, and TCPStreamIntfModule to capture the client IP address and port when a connection is established. Expose this information through the serial interface for debugging, enabling visibility into the connected client's network details.